### PR TITLE
MIDI integration and synthesis refinement

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,7 +19,7 @@ AlwaysBreakTemplateDeclarations: 'true'
 BinPackArguments: 'false'
 BinPackParameters: 'false'
 BreakConstructorInitializersBeforeComma: 'false'
-ColumnLimit: '80'
+ColumnLimit: '100'
 ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
 ConstructorInitializerIndentWidth: '0'
 Cpp11BracedListStyle: 'true'
@@ -32,7 +32,7 @@ KeepEmptyLinesAtTheStartOfBlocks: 'false'
 Language: Cpp
 MaxEmptyLinesToKeep: '2'
 NamespaceIndentation: Inner
-ReflowComments: 'false'
+ReflowComments: 'true'
 SpaceAfterCStyleCast: 'false'
 SpaceBeforeAssignmentOperators: 'true'
 SpaceBeforeParens: Never

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,63 @@
+---
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignEscapedNewlinesLeft: 'true'
+AlignOperands: true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: 'false'
+AllowShortBlocksOnASingleLine: 'true'
+AllowShortCaseLabelsOnASingleLine: 'true'
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: 'false'
+AllowShortLoopsOnASingleLine: 'false'
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: 'true'
+AlwaysBreakTemplateDeclarations: 'true'
+BinPackArguments: 'false'
+BinPackParameters: 'false'
+BreakConstructorInitializersBeforeComma: 'false'
+ColumnLimit: '80'
+ConstructorInitializerAllOnOneLineOrOnePerLine: 'true'
+ConstructorInitializerIndentWidth: '0'
+Cpp11BracedListStyle: 'true'
+DerivePointerAlignment: 'true'
+DisableFormat: 'false'
+IndentCaseLabels: 'true'
+IndentWidth: '2'
+IndentWrappedFunctionNames: 'false'
+KeepEmptyLinesAtTheStartOfBlocks: 'false'
+Language: Cpp
+MaxEmptyLinesToKeep: '2'
+NamespaceIndentation: Inner
+ReflowComments: 'false'
+SpaceAfterCStyleCast: 'false'
+SpaceBeforeAssignmentOperators: 'true'
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: 'false'
+SpacesInCStyleCastParentheses: 'false'
+SpacesInContainerLiterals: 'false'
+SpacesInParentheses: 'false'
+SpacesInSquareBrackets: 'false'
+Standard: Cpp11
+UseTab: Never
+TabWidth: 4
+SortIncludes: false
+AccessModifierOffset: -2
+
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       true
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: true
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+BreakBeforeBraces: Allman
+BreakBeforeBinaryOperators: All

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 ._.DS_Store
 .DS_Store
 
+/hardware/**
+
 /**/build/
 
 # Prerequisites

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,38 +1,26 @@
 {
-  "configurations": [
-    {
-      "cStandard": "c11",
-      "compilerPath": "arm-none-eabi-g++.exe",
-      "cppStandard": "c++17",
-      "defines": [
-        "_DEBUG",
-        "UNICODE",
-        "_UNICODE"
-      ],
-      "includePath": [
-        "${workspaceFolder}/**",
-        "${config:electrosmithFolder}/libDaisy/**",
-        "${config:electrosmithFolder}/DaisySP/**"
-      ],
-      "name": "Win32",
-      "windowsSdkVersion": "10.0.17763.0"
-    },
-    {
-      "cStandard": "c11",
-      "compilerPath": "/usr/local/bin/arm-none-eabi-g++",
-      "cppStandard": "c++17",
-      "defines": [
-        "_DEBUG",
-        "UNICODE",
-        "_UNICODE"
-      ],
-      "includePath": [
-        "${workspaceFolder}/**",
-        "${config:electrosmithFolder}/libDaisy/**",
-        "${config:electrosmithFolder}/DaisySP/**"
-      ],
-      "name": "macOS"
-    }
-  ],
-  "version": 4
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "${workspaceFolder}/**",
+                "${config:electrosmithFolder}/libDaisy/src",
+                "${config:electrosmithFolder}/DaisySP/Source",
+                "${config:electrosmithFolder}/libDaisy/Drivers/STM32H7xx_HAL_Driver/Inc",
+                "${config:electrosmithFolder}/libDaisy/src/sys",
+                "${config:electrosmithFolder}/libDaisy/Drivers/CMSIS-Device/ST/STM32H7xx/Include",
+                "${config:electrosmithFolder}/libDaisy/Middlewares/ST/STM32_USB_Host_Library/Core/Inc",
+                "${config:electrosmithFolder}/libDaisy/src/usbh",
+                "${config:electrosmithFolder}/libDaisy/Middlewares/Third_Party/FatFs/src",
+                "${config:electrosmithFolder}/libDaisy/Drivers/CMSIS_5/CMSIS/Core/Include"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "macos-clang-arm64",
+            "configurationProvider": "ms-vscode.makefile-tools"
+        }
+    ],
+    "version": 4
 }

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -11,8 +11,8 @@
       ],
       "includePath": [
         "${workspaceFolder}/**",
-        "${config:daisyExamplesFolder}/libDaisy/**",
-        "${config:daisyExamplesFolder}/DaisySP/**"
+        "${config:electrosmithFolder}/libDaisy/**",
+        "${config:electrosmithFolder}/DaisySP/**"
       ],
       "name": "Win32",
       "windowsSdkVersion": "10.0.17763.0"
@@ -28,8 +28,8 @@
       ],
       "includePath": [
         "${workspaceFolder}/**",
-        "${config:daisyExamplesFolder}/libDaisy/**",
-        "${config:daisyExamplesFolder}/DaisySP/**"
+        "${config:electrosmithFolder}/libDaisy/**",
+        "${config:electrosmithFolder}/DaisySP/**"
       ],
       "name": "macOS"
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,9 +24,13 @@
         "monitor reset"
       ],
       "request": "launch",
-      "runToMain": true,
+      "runToEntryPoint": "true",
       "servertype": "openocd",
-      "showDevDebugOutput": true,
+      "liveWatch": {
+        "enabled": true,
+        "samplesPerSecond": 4
+      },
+      "showDevDebugOutput": "vscode",
       "svdFile": "${workspaceRoot}/.vscode/STM32H750x.svd",
       "type": "cortex-debug"
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,9 @@
       "cwd": "${workspaceFolder}",
       "debuggerArgs": [
         "-d",
-        "${workspaceRoot}"
+        "${workspaceFolder}"
       ],
-      "executable": "${workspaceRoot}/build/twiggsynth.elf",
+      "executable": "${workspaceFolder}/build/twiggsynth.elf",
       "interface": "swd",
       "name": "Cortex Debug",
       "openOCDLaunchCommands": [
@@ -31,7 +31,7 @@
         "samplesPerSecond": 4
       },
       "showDevDebugOutput": "vscode",
-      "svdFile": "${workspaceRoot}/.vscode/STM32H750x.svd",
+      "svdFile": "${workspaceFolder}/.vscode/STM32H750x.svd",
       "type": "cortex-debug"
     }
   ],

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "daisyExamplesFolder": "${workspaceFolder}/../electro-smith/DaisyExamples",
+  "electrosmithFolder": "${workspaceFolder}/../electro-smith",
   "workspaceKeybindings.daisyseed.enabled": true,
   "files.associations": {
     "iostream": "cpp",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "electrosmithFolder": "${workspaceFolder}/../electro-smith",
-  "workspaceKeybindings.daisyseed.enabled": true,
   "files.associations": {
     "iostream": "cpp",
     "cmath": "cpp",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "daisyExamplesFolder": "${workspaceFolder}/../DaisyExamples",
+  "daisyExamplesFolder": "${workspaceFolder}/../electro-smith/DaisyExamples",
   "workspaceKeybindings.daisyseed.enabled": true,
   "files.associations": {
     "iostream": "cpp",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -66,5 +66,6 @@
     "thread": "cpp",
     "typeinfo": "cpp",
     "variant": "cpp"
-  }
+  },
+  "cortex-debug.liveWatchRefreshRate": 500
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "electrosmithFolder": "${workspaceFolder}/../electro-smith",
+  "electrosmithFolder": "/Users/glenntwiggs/Projects/daisy-seed/electro-smith",
   "files.associations": {
     "iostream": "cpp",
     "cmath": "cpp",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -83,7 +83,7 @@
       "command": "make",
       "label": "build_libdaisy",
       "options": {
-        "cwd": "${config:daisyExamplesFolder}/libDaisy"
+        "cwd": "${config:electrosmithFolder}/libDaisy"
       },
       "problemMatcher": [
         "$gcc"
@@ -94,7 +94,7 @@
       "command": "make",
       "label": "build_daisysp",
       "options": {
-        "cwd": "${config:daisyExamplesFolder}/DaisySP"
+        "cwd": "${config:electrosmithFolder}/DaisySP"
       },
       "problemMatcher": [
         "$gcc"

--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,12 @@ TARGET = Twiggsynth
 
 USE_DAISYSP_LGPL = 1
 
-# DaisyExample repo root directory
-DAISYEXAMPLES_DIR = ../electro-smith/DaisyExamples
-
 # Sources
 CPP_SOURCES = Twiggsynth.cpp
 
 # Library Locations
-LIBDAISY_DIR = $(DAISYEXAMPLES_DIR)/libDaisy
-DAISYSP_DIR = $(DAISYEXAMPLES_DIR)/DaisySP
+LIBDAISY_DIR = ../electro-smith/libDaisy
+DAISYSP_DIR = ../electro-smith/DaisySP
 
 # Core location, and generic makefile.
 SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ TARGET = Twiggsynth
 
 USE_DAISYSP_LGPL = 1
 
-C_INCLUDES = \
-	-ISource/
+C_INCLUDES = -ISource/
 
 # Sources
 CPP_SOURCES = \

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,13 @@ TARGET = Twiggsynth
 
 USE_DAISYSP_LGPL = 1
 
+C_INCLUDES = \
+	-ISource/
+
 # Sources
-CPP_SOURCES = Twiggsynth.cpp
+CPP_SOURCES = \
+	Source/TsPort.cpp \
+	Twiggsynth.cpp
 
 # Library Locations
 LIBDAISY_DIR = ../electro-smith/libDaisy

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TARGET = Twiggsynth
 USE_DAISYSP_LGPL = 1
 
 # DaisyExample repo root directory
-DAISYEXAMPLES_DIR = ../DaisyExamples
+DAISYEXAMPLES_DIR = ../electro-smith/DaisyExamples
 
 # Sources
 CPP_SOURCES = Twiggsynth.cpp

--- a/README.md
+++ b/README.md
@@ -27,21 +27,33 @@ A learning platform for music synthesis using a Daisy Seed.
   - UART MIDI ~ 5 pin DIN.
   - Note on/off.
   - Pitch bend +/- 1 octave.
+  - Channel Pressure modulates Tremolo
   - Listens on all channels.
 - Hardware controls:
-  - `K1`: Volume
-  - `K2`: LFO frequency: modulates the filter cutoff.
-  - `K3`: Sub-oscillator detune: 0 to -2 octaves.
-  - `K4`: Flter resonance.
-  - `K5`: Attack time.
-  - `K6`: Release time.
-  - `B1 + K6`: Portamento time.
+  - `k1`: Volume
+  - `k2`: Flter resonance.
+  - `k3`: Attack time.
+  - `k4`: Release time.
+  - `k5`: Portamento time.
+  - `k6`: _unassigned_
+  - `k7`: LFO frequency: modulates the filter cutoff.
+  - `k8`: Sub-oscillator detune: 0 to -2 octaves.
+  - `k9`: _unassigned_
+  - `s1`: _unassigned_
+  - `led`: Power
 
 ```
-MIDI Rx   |
-MIDI Tx   |   B1
-----------+----------------------
-       K1 |
-          |  K2  K3  K4   K5  K6
-    S1 S2 |
++----------------------+
+|  k1         led      |
+|        k2            |
+|              k3      |
+|   k7                 |
+|                 k4   |
+|         k8           |
+|                 k5   |
+|                      |
+|             k6    /  |
+|     k9          s1   |
+|                /     |
++----------------------+
 ```

--- a/README.md
+++ b/README.md
@@ -1,34 +1,32 @@
-# Twiggsynth
+# Twigg*synth*
 
 ## Author
 
-Gtwiggs
+@Gtwiggs
 
 ## Description
 
-A digital synthesis musical instrument.
-
-_Twigg**synth**_ is a learning platform for _so many things_. Some loose goals:
-
-- Organizing code to make the addition/removal and declaration of hardware components easy.
-- Software-based routing between instrument components based on panel input.
-- Self-playing, maybe with seed note(s).
-- Paraphonic.
+A learning platform for music synthesis using a Daisy Seed.
 
 ## State Of Play
 
-**_3/14/2025_**
+**_3/19/2025_**
 
-- Monophonic synthesizer.
+- 2 Oscillator Monophonic synthesizer.
   - Suboscillator tied to main oscillator.
-  - New notes replace prior notes.
+  - Oscillator and suboscillator waveform: sawtooth.
+  - Latest note priority.
   - If a note is held, it will resume playing after later notes are released.
-  - Portamento for held notes. Resets when no notes are active. Fixed at 0.05s.
+  - Portamento across entire range. Resets when no notes are active. Fixed glide time of 0.05s.
 - Mono output.
-- Note input via UART MIDI.
+- LFO Mod source; waveform: triangle
+- Ladder Filter.
+  - Low Pass 2 pole filter.
+- Fixed ADSR envelope.
+- Note on/off input via UART MIDI.
   - Listens on all channels.
 - Hardware controls:
   - Volume
-  - LFO frequency: LFO modulates the Moog Ladder filter cutoff.
-  - Sub-oscillator detune: 0 to -2 octaves. Waveform: Sawtooth
-  - Moog Ladder flter resonance.
+  - LFO frequency: modulates the filter cutoff.
+  - Sub-oscillator detune: 0 to -2 octaves.
+  - Flter resonance.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ A learning platform for music synthesis using a Daisy Seed.
 - Ladder Filter.
   - Low Pass 2 pole filter.
 - Fixed ADSR envelope.
-- Note on/off input via UART MIDI.
+- MIDI Support:
+  - UART MIDI ~ 5 pin DIN.
+  - Note on/off.
+  - Pitch bend +/- 1 octave.
   - Listens on all channels.
 - Hardware controls:
   - Volume

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ A learning platform for music synthesis using a Daisy Seed.
 -   Ladder Filter.
     -   Low Pass 2 pole filter.
 -   ADSR envelope.
+    - Attack 0s - 5s.
+    - Decay not settable.
+    - Sustain level 1 - 0.
+    - Release 0s - note hold.
 -   MIDI Support:
     -   UART MIDI ~ 5 pin DIN.
     -   Note on/off.
@@ -35,16 +39,16 @@ A learning platform for music synthesis using a Daisy Seed.
 | Label | Pin | Function                                                  |
 | :---: | :-: | --------------------------------------------------------- |
 |  k1   | D24 | Volume                                                    |
-|  k2   | D23 | Flter resonance.                                          |
-|  k3   | D20 | Attack time.                                              |
-|  k4   | D15 | Release time.                                             |
-|  k5   | D16 | Portamento time.                                          |
-|  k6   | D18 | _unassigned_                                              |
+|  k2   | D23 | Flter cutoff.                                             |
+|  k3   | D20 | Flter resonance.                                          |
+|  k4   | D15 | Attack time.                                              |
+|  k5   | D16 | Sustain level.                                            |
+|  k6   | D18 | Release time.                                             |
 |  k7   | D22 | LFO frequency: modulates the filter cutoff. Disabled @ 0. |
 |  k8   | D21 | Sub-oscillator detune: 0 to -2 octaves.                   |
-|  k9   | D19 | _unassigned_                                              |
+|  k9   | D19 | Portamento time.                                          |
 |  s1   | D17 | _unassigned_                                              |
-|  led  |     | Power                                                     |
+|  led  |     | Power indicator                                           |
 
 ```
 +----------------------+

--- a/README.md
+++ b/README.md
@@ -12,35 +12,39 @@ A learning platform for music synthesis using a Daisy Seed.
 
 **_3/19/2025_**
 
-- 2 Oscillator Monophonic synthesizer.
-  - Oscillator and suboscillator waveform: sawtooth.
-  - Suboscillator frequency referenced to main oscillator.
-  - Latest note priority.
-  - If a note is held, it will resume playing after later notes are released.
-  - Portamento across entire range. Resets when no notes are active. Fixed glide time of 0.05s.
-- Mono output.
-- LFO Mod source; waveform: triangle
-- Ladder Filter.
-  - Low Pass 2 pole filter.
-- ADSR envelope.
-- MIDI Support:
-  - UART MIDI ~ 5 pin DIN.
-  - Note on/off.
-  - Pitch bend +/- 1 octave.
-  - Channel Pressure modulates Tremolo
-  - Listens on all channels.
-- Hardware controls:
-  - `k1`: Volume
-  - `k2`: Flter resonance.
-  - `k3`: Attack time.
-  - `k4`: Release time.
-  - `k5`: Portamento time.
-  - `k6`: _unassigned_
-  - `k7`: LFO frequency: modulates the filter cutoff.
-  - `k8`: Sub-oscillator detune: 0 to -2 octaves.
-  - `k9`: _unassigned_
-  - `s1`: _unassigned_
-  - `led`: Power
+-   2 Oscillator Monophonic synthesizer.
+    -   Oscillator and suboscillator waveform: sawtooth.
+    -   Suboscillator frequency referenced to main oscillator.
+    -   Latest note priority.
+    -   If a note is held, it will resume playing after later notes are released.
+    -   Portamento across entire range. Resets when no notes are active. Fixed glide time of 0.05s.
+-   Mono output.
+-   LFO Mod source; waveform: triangle
+-   Ladder Filter.
+    -   Low Pass 2 pole filter.
+-   ADSR envelope.
+-   MIDI Support:
+    -   UART MIDI ~ 5 pin DIN.
+    -   Note on/off.
+    -   Pitch bend +/- 1 octave.
+    -   Channel Pressure modulates Tremolo
+    -   Listens on all channels.
+
+## Hardware Controls
+
+| Label | Pin | Function                                                  |
+| :---: | :-: | --------------------------------------------------------- |
+|  k1   | D24 | Volume                                                    |
+|  k2   | D23 | Flter resonance.                                          |
+|  k3   | D20 | Attack time.                                              |
+|  k4   | D15 | Release time.                                             |
+|  k5   | D16 | Portamento time.                                          |
+|  k6   | D18 | _unassigned_                                              |
+|  k7   | D22 | LFO frequency: modulates the filter cutoff. Disabled @ 0. |
+|  k8   | D21 | Sub-oscillator detune: 0 to -2 octaves.                   |
+|  k9   | D19 | _unassigned_                                              |
+|  s1   | D17 | _unassigned_                                              |
+|  led  |     | Power                                                     |
 
 ```
 +----------------------+

--- a/README.md
+++ b/README.md
@@ -10,30 +10,25 @@ A digital synthesis musical instrument.
 
 _Twigg**synth**_ is a learning platform for _so many things_. Some loose goals:
 
-- Organizing code to make the addition/removal and declaration of on-board components easy.
+- Organizing code to make the addition/removal and declaration of hardware components easy.
 - Software-based routing between instrument components based on panel input.
 - Self-playing, maybe with seed note(s).
-- Monophonic, perhaps paraphonic.
+- Paraphonic.
 
 ## State Of Play
 
-**_2/5/2024_**
+**_3/14/2025_**
 
-- Monophonic synthesis.
+- Monophonic synthesizer.
   - Suboscillator tied to main oscillator.
   - New notes replace prior notes.
   - If a note is held, it will resume playing after later notes are released.
   - Portamento for held notes. Resets when no notes are active. Fixed at 0.05s.
-- Note input via USB MIDI on the builtin connector.
+- Mono output.
+- Note input via UART MIDI.
   - Listens on all channels.
-- Leftmost Knob controls the sub-oscillator detune.
-  - It ranges from no detune (fully clockwise) to -2 octaves (fully counterclockwise).
-- Center knob controls LFO Rate
-  - LFO modulates the Moog Ladder filter cutoff.
-  - Filter resonance is fixed (at 0.7)
-- Rightmost knob controls volume.
-- 3-position toggle switch chooses the subosc contribution:
-  - UP: subosc is a Sawtooth waveform.
-  - CENTER: subosc is a Sine waveform.
-  - DOWN: subosc is disabled.
-- Mini jack is L/Mono line level out.
+- Hardware controls:
+  - Volume
+  - LFO frequency: LFO modulates the Moog Ladder filter cutoff.
+  - Sub-oscillator detune: 0 to -2 octaves. Waveform: Sawtooth
+  - Moog Ladder flter resonance.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A learning platform for music synthesis using a Daisy Seed.
 
 ## State Of Play
 
-**_3/19/2025_**
+**_4/15/2025_**
 
 -   2 Oscillator Monophonic synthesizer.
     -   Oscillator and suboscillator waveform: sawtooth.
@@ -19,16 +19,20 @@ A learning platform for music synthesis using a Daisy Seed.
     -   If a note is held, it will resume playing after later notes are released.
     -   Portamento across entire range. Resets when no notes are active. Fixed glide time of 0.05s.
 -   Mono output.
--   LFO Mod source; waveform: triangle
+-   LFO Mod source; waveform: triangle.
 -   Ladder Filter.
     -   Low Pass 2 pole filter.
+-   Tremolo accessed via MIDI channel pressure. 50% wet/dry, Triangle waveform.
 -   ADSR envelope.
-    - Attack 0s - 5s.
-    - Decay not settable.
-    - Sustain level 1 - 0.
-    - Release 0s - note hold.
+    -   Attack 0s - 5s.
+    -   Decay not settable.
+    -   Sustain level 1 - 0.
+    -   Release 0s - note hold.
+-   Slider to select waveforms.
+    -   Sets toe waveforms for the main and sub oscillators.
+    -   The slider provides access t all 9 combinations of Sawtooth, Square and Triangle waveforms.
 -   MIDI Support:
-    -   UART MIDI ~ 5 pin DIN.
+    -   UART MIDI ~ 5 pin DIN connectors. _IN_ and _OUT_ connectors are provided, but only _IN_ is implemented.
     -   Note on/off.
     -   Pitch bend +/- 1 octave.
     -   Channel Pressure modulates Tremolo
@@ -47,7 +51,7 @@ A learning platform for music synthesis using a Daisy Seed.
 |  k7   | D22 | LFO frequency: modulates the filter cutoff. Disabled @ 0. |
 |  k8   | D21 | Sub-oscillator detune: 0 to -2 octaves.                   |
 |  k9   | D19 | Portamento time.                                          |
-|  s1   | D17 | _unassigned_                                              |
+|  s1   | D17 | Waveform Picker for main and sub oscillators.             |
 |  led  |     | Power indicator                                           |
 
 ```

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ A learning platform for music synthesis using a Daisy Seed.
 **_3/19/2025_**
 
 - 2 Oscillator Monophonic synthesizer.
-  - Suboscillator tied to main oscillator.
   - Oscillator and suboscillator waveform: sawtooth.
+  - Suboscillator frequency referenced to main oscillator.
   - Latest note priority.
   - If a note is held, it will resume playing after later notes are released.
   - Portamento across entire range. Resets when no notes are active. Fixed glide time of 0.05s.
@@ -22,14 +22,26 @@ A learning platform for music synthesis using a Daisy Seed.
 - LFO Mod source; waveform: triangle
 - Ladder Filter.
   - Low Pass 2 pole filter.
-- Fixed ADSR envelope.
+- ADSR envelope.
 - MIDI Support:
   - UART MIDI ~ 5 pin DIN.
   - Note on/off.
   - Pitch bend +/- 1 octave.
   - Listens on all channels.
 - Hardware controls:
-  - Volume
-  - LFO frequency: modulates the filter cutoff.
-  - Sub-oscillator detune: 0 to -2 octaves.
-  - Flter resonance.
+  - `K1`: Volume
+  - `K2`: LFO frequency: modulates the filter cutoff.
+  - `K3`: Sub-oscillator detune: 0 to -2 octaves.
+  - `K4`: Flter resonance.
+  - `K5`: Attack time.
+  - `K6`: Release time.
+  - `B1 + K6`: Portamento time.
+
+```
+MIDI Rx   |
+MIDI Tx   |   B1
+----------+----------------------
+       K1 |
+          |  K2  K3  K4   K5  K6
+    S1 S2 |
+```

--- a/Source/TsPort.cpp
+++ b/Source/TsPort.cpp
@@ -1,0 +1,38 @@
+#include "TsPort.h"
+
+#include <math.h>
+#include <stdlib.h>
+#define ROOT2 (1.4142135623730950488)
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+using namespace daisysp;
+
+void TsPort::Init(float sample_rate, float htime)
+{
+    yt1_     = 0;
+    prvhtim_ = -100.0;
+    htime_   = htime;
+
+    sample_rate_ = sample_rate;
+    onedsr_      = 1.0 / sample_rate_;
+}
+
+float TsPort::Process(float in)
+{
+    if(prvhtim_ != htime_)
+    {
+        c2_      = pow(0.5, onedsr_ / htime_);
+        c1_      = 1.0 - c2_;
+        prvhtim_ = htime_;
+    }
+
+    return yt1_ = c1_ * in + c2_ * yt1_;
+}
+
+// New method implementation
+void TsPort::SetFreq(float f) {
+    yt1_ = f;
+}

--- a/Source/TsPort.h
+++ b/Source/TsPort.h
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2023 Electrosmith, Corp, Robbin Whittle, John ffitch, Paul Batchelor, Glenn Twiggs
+
+Use of this source code is governed by the LGPL V2.1
+license that can be found in the LICENSE file or at
+https://opensource.org/license/lgpl-2-1/
+*/
+#ifndef TSPORT_H
+#define TSPORT_H
+
+namespace daisysp
+{
+/** Applies portamento to an input signal. 
+
+At each new step value, the input is low-pass filtered to 
+move towards that value at a rate determined by ihtim. ihtim is the half-time of the 
+function (in seconds), during which the curve will traverse half the distance towards the new value, 
+then half as much again, etc., theoretically never reaching its asymptote.
+
+Modified by @gtwiggs to include the SetFreq method.
+*/
+class TsPort
+{
+  public:
+    TsPort() {}
+    ~TsPort() {}
+    /** Initializes Port module
+
+        \param sample_rate: sample rate of audio engine
+        \param htime: half-time of the function, in seconds.
+    */
+
+    void Init(float sample_rate, float htime);
+
+    /** Applies portamento to input signal and returns processed signal. 
+        \return slewed output signal
+    */
+    float Process(float in);
+
+
+    /** Sets htime
+    */
+    inline void SetHtime(float htime) { htime_ = htime; }
+    /** returns current value of htime
+    */
+    inline float GetHtime() { return htime_; }
+
+    /**
+     * Sets the starting point frequency.
+     * Useful for "resetting" the frequency glide to the current note.
+     * 
+     * \param f: frequency to set the starting point for portamento.
+     */
+    void SetFreq(float f);
+
+  private:
+    float htime_;
+    float c1_, c2_, yt1_, prvhtim_;
+    float sample_rate_, onedsr_;
+};
+} // namespace daisysp
+
+#endif // TSPORT_H

--- a/Twiggsynth.cpp
+++ b/Twiggsynth.cpp
@@ -67,7 +67,7 @@ std::vector<AnalogControlDefn> analogControlDefns = {
     {SUBOSC_FREQ_DETUNE, KNOB_8_PIN,  0.0f,   26.0f,    Parameter::LINEAR,      true },
     {CUTOFF,             KNOB_2_PIN,  25.0f,  12000.0f, Parameter::EXPONENTIAL, false},
     {RESONANCE,          KNOB_3_PIN,  0.0f,   1.8f,     Parameter::EXPONENTIAL, false},
-    {ATTACK,             KNOB_4_PIN,  0.0f,   10.f,     Parameter::EXPONENTIAL, false},
+    {ATTACK,             KNOB_4_PIN,  0.0f,   5.f,      Parameter::EXPONENTIAL, false},
     {RELEASE,            KNOB_5_PIN,  0.0f,   10.01f,   Parameter::EXPONENTIAL, false},
     {PORT,               KNOB_6_PIN,  0.0f,   1.0f,     Parameter::LINEAR,      false},
     {KNOB_9,             KNOB_9_PIN,  0.0f,   1.0f,     Parameter::LINEAR,      false},
@@ -217,12 +217,9 @@ void AudioCallback(AudioHandle::InterleavingInputBuffer  in,
     //    alternate between full signal strength to complete suppression of the signal at the
     //    frequency rate of the LFO.  For a more subtle effect, a depth of around 30% or so will
     //    result in a much smoother amplitude variance of the signal.
-    if(channel_pressure > 0.0f)
-    {
-      // apply a logarithmic curve to value.
-      tremolo.SetFreq(expf(channel_pressure / 127.0f * logf(10.0f)));
-      filtered_out = tremolo.Process(filtered_out);
-    }
+
+    tremolo.SetFreq(channel_pressure / 127.0f * 10.0f);
+    filtered_out = tremolo.Process(filtered_out);
 
     // Set the left and right outputs
 
@@ -398,8 +395,8 @@ void InitSynth(float samplerate)
 
   tremolo.Init(samplerate);
   tremolo.SetFreq(0.0f);
-  tremolo.SetDepth(0.3f);
-  tremolo.SetWaveform(Oscillator::WAVE_SIN);
+  tremolo.SetDepth(0.5f);
+  tremolo.SetWaveform(Oscillator::WAVE_POLYBLEP_TRI);
 
   wf.Init();
   subWf.Init();

--- a/Twiggsynth.h
+++ b/Twiggsynth.h
@@ -8,23 +8,23 @@ enum AnalogControlName : unsigned int;
 
 struct AnalogControlDefn
 {
-    AnalogControlName name;
-    Pin               pin;
-    float             min;
-    float             max;
-    Parameter::Curve  curve;
-    bool              flipped;
+  AnalogControlName name;
+  Pin               pin;
+  float             min;
+  float             max;
+  Parameter::Curve  curve;
+  bool              flipped;
 
-    // Constructor
-    AnalogControlDefn(AnalogControlName name,
-                      Pin               pin,
-                      float             min,
-                      float             max,
-                      Parameter::Curve  curve,
-                      bool              flipped = false)
-    : name(name), pin(pin), min(min), max(max), curve(curve), flipped(flipped)
-    {
-    }
+  // Constructor
+  AnalogControlDefn(AnalogControlName name,
+                    Pin               pin,
+                    float             min,
+                    float             max,
+                    Parameter::Curve  curve,
+                    bool              flipped = false)
+  : name(name), pin(pin), min(min), max(max), curve(curve), flipped(flipped)
+  {
+  }
 };
 
 void InitMidi();
@@ -39,6 +39,6 @@ void ProcessMidi();
 /** Process Analog and Digital Controls */
 inline void ProcessAllControls()
 {
-    ProcessAnalogControls();
-    ProcessDigitalControls();
+  ProcessAnalogControls();
+  ProcessDigitalControls();
 }

--- a/Twiggsynth.h
+++ b/Twiggsynth.h
@@ -41,6 +41,15 @@ struct AnalogControlDefn
  */
 float PitchMultiplier(float offset, int semitoneRange);
 
+/**
+ * @brief Map a float value to an int range.
+ * @param val The float value to map. Must be in the range 0.0 to 1.0 inclusive.
+ * @param minInt The minimum int value.
+ * @param maxInt The maximum int value.
+ * @return The mapped int value.
+ */
+int MapControlToRange(float val, int minInt, int maxInt);
+
 void InitMidi();
 void InitSynth(float samplerate);
 void InitAnalogControls();

--- a/Twiggsynth.h
+++ b/Twiggsynth.h
@@ -14,6 +14,7 @@ struct AnalogControlDefn
   float             max;
   Parameter::Curve  curve;
   bool              flipped;
+  float             slew_seconds;
 
   // Constructor
   AnalogControlDefn(AnalogControlName name,
@@ -21,8 +22,15 @@ struct AnalogControlDefn
                     float             min,
                     float             max,
                     Parameter::Curve  curve,
-                    bool              flipped = false)
-  : name(name), pin(pin), min(min), max(max), curve(curve), flipped(flipped)
+                    bool              flipped,
+                    float             slew_seconds = 0.0f)
+  : name(name),
+    pin(pin),
+    min(min),
+    max(max),
+    curve(curve),
+    flipped(flipped),
+    slew_seconds(slew_seconds)
   {
   }
 };

--- a/Twiggsynth.h
+++ b/Twiggsynth.h
@@ -35,6 +35,12 @@ struct AnalogControlDefn
   }
 };
 
+/**
+ * PitchMultiplier returns a frequency multiplier based on an offset and a range in semitones.
+ * The offset is a value between 0 and 1.
+ */
+float PitchMultiplier(float offset, int semitoneRange);
+
 void InitMidi();
 void InitSynth(float samplerate);
 void InitAnalogControls();

--- a/Twiggsynth.h
+++ b/Twiggsynth.h
@@ -30,7 +30,7 @@ struct AnalogControlDefn
 void InitMidi();
 void InitSynth(float samplerate);
 void InitAnalogControls();
-void InitSwitches();
+void InitDigitalControls(float samplerate);
 
 void ProcessAnalogControls();
 void ProcessDigitalControls();

--- a/Twiggsynth.h
+++ b/Twiggsynth.h
@@ -6,17 +6,25 @@ using namespace daisysp;
 
 enum AnalogControlName : unsigned int;
 
-struct AnalogControlDefn {
+struct AnalogControlDefn
+{
     AnalogControlName name;
-    Pin pin;
-    float min;
-    float max;
-    Parameter::Curve curve;
-    bool flipped;
+    Pin               pin;
+    float             min;
+    float             max;
+    Parameter::Curve  curve;
+    bool              flipped;
 
     // Constructor
-    AnalogControlDefn(AnalogControlName name, Pin pin, float min, float max, Parameter::Curve curve, bool flipped = false)
-        : name(name), pin(pin), min(min), max(max), curve(curve), flipped(flipped) {}
+    AnalogControlDefn(AnalogControlName name,
+                      Pin               pin,
+                      float             min,
+                      float             max,
+                      Parameter::Curve  curve,
+                      bool              flipped = false)
+    : name(name), pin(pin), min(min), max(max), curve(curve), flipped(flipped)
+    {
+    }
 };
 
 void InitMidi();
@@ -31,6 +39,6 @@ void ProcessMidi();
 /** Process Analog and Digital Controls */
 inline void ProcessAllControls()
 {
-  ProcessAnalogControls();
-  ProcessDigitalControls();
+    ProcessAnalogControls();
+    ProcessDigitalControls();
 }


### PR DESCRIPTION
## Changes
- Replaced Subosc strategy with 16-step frequency divider
- Implemented Waveform Picker using slider
- Added sustain knob with release max note hold
- Improved algorithms for:
  - Suboscillator detune
  - Tremolo
  - Filter cutoff
- Added various MIDI controls:
  - Tremolo via channel pressure
  - Pitch bend support
  - Mod wheel for wavefolding
- Enhanced hardware controls for Attack, Decay & slew time
- Replaced MoogFilter with LadderFilter
- Added fixed ADSR envelope
- Fixed clicking noise issues
- Added limiter and wavefolder
- Implemented UART MIDI support with filter resonance control